### PR TITLE
vigiles: return non-zero exit code on failure

### DIFF
--- a/src/bin/vigiles
+++ b/src/bin/vigiles
@@ -424,7 +424,7 @@ if __name__ == '__main__':
     if parsed_args.command == 'version':
         print(llapi.version)
         sys.exit(0)
-    
+
     # Catch key/config load failures here to avoid raw traceback output in CLI
     try:
         # Configure LLAPI object
@@ -436,7 +436,7 @@ if __name__ == '__main__':
             dry_run=parsed_args.dry_run,
         )
     except Exception as err:
-        print(err)
+        print(err, file=sys.stderr)
         sys.exit(1)
 
     # Call the corresponding API method for the given command line args
@@ -729,7 +729,8 @@ if __name__ == '__main__':
         else:
             raise Exception(f'Unhandled command: {parsed_args.command}')
     except Exception as err:
-        print(err)
+        print(err, file=sys.stderr)
+        sys.exit(1)
     else:  # command returned normally
         if parsed_args.no_format:
             print(result)


### PR DESCRIPTION
This is important for CI/CD setup which need to detect e.g. transient networking errors or other failures to submit a SBoM to Vigiles for review.

fixes #2